### PR TITLE
Added consumer id validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ todo
 
 # contains config for the application
 config.yml
+tmp/build-errors.log

--- a/entryPoint.go
+++ b/entryPoint.go
@@ -25,13 +25,13 @@ func main() {
 		log.Println("Vault is unreachable")
 	}
 
-	var serverOn string
+	var serveOn string
 	if endpoints.OperatingSystem == "windows" {
-		serverOn = "localhost:8080"
+		serveOn = "localhost:8080"
 	} else {
-		serverOn = ":8080"
+		serveOn = ":8080"
 	}
-	router.Run(serverOn) // listen and serve on "localhost:8080"
+	router.Run(serveOn) // listen and serve on "localhost:8080"
 }
 
 // Custom panic recovery middleware

--- a/isolatedfunctions/functions.go
+++ b/isolatedfunctions/functions.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -74,4 +75,17 @@ func POSTjsonPayload(c *gin.Context, authToken, requestType, url string, payload
 
 	body, _ := io.ReadAll(resp.Body) // Reads the body from http.Response and converts it into []byte
 	return body, err
+}
+
+func ConsumerIDValidator(c *gin.Context, consumerID string) bool {
+	availableConsumers := endpoints.ConfigData.Consumers
+	found := slices.Contains(availableConsumers, consumerID)
+
+	if !found {
+		c.JSON(http.StatusBadGateway, gin.H{
+			"status": "failed",
+			"reason": "Provided consumer is invalid ,please provide a valid consumer id",
+		})
+	}
+	return found
 }

--- a/tasks/servicenowTasks.go
+++ b/tasks/servicenowTasks.go
@@ -75,6 +75,10 @@ func CreateSNOWIncident(c *gin.Context) {
 		return
 	}
 
+	if test := isolatedfunctions.ConsumerIDValidator(c, req.ConsumerId); test != true {
+		return
+	}
+
 	snowURL, snowAuthToken, err := authorizations.GetSNOWAuthToken()
 	if err != nil {
 		log.Println("Failed to fetch SNOW auth token")
@@ -150,6 +154,10 @@ func GetSNOWIncident(c *gin.Context) {
 		return
 	}
 
+	if test := isolatedfunctions.ConsumerIDValidator(c, req.ConsumerId); test != true {
+		return
+	}
+
 	snowURL, snowAuthToken, err := authorizations.GetSNOWAuthToken()
 	if err != nil {
 		log.Println("Failed to fetch SNOW auth token")
@@ -193,6 +201,10 @@ func UpdateSNOWIncident(c *gin.Context) {
 	validateRequest := c.ShouldBindHeader(&req)
 	if validateRequest != nil {
 		c.String(http.StatusBadRequest, "Please provide all necessary headers ConsumerId, IncidentNum.")
+		return
+	}
+
+	if test := isolatedfunctions.ConsumerIDValidator(c, req.ConsumerId); test != true {
 		return
 	}
 


### PR DESCRIPTION
Added consumer id validation for the SNOW task calls .

User will get below response if the provided consumer id is not part of consumers .

```json
{
    "reason": "Provided consumer is invalid ,please provide a valid consumer id",
    "status": "failed"
}
```